### PR TITLE
Fix mistake in ReadCSVBool ("if" where it was supposed to be "else if")

### DIFF
--- a/smbx64.h
+++ b/smbx64.h
@@ -163,7 +163,7 @@ namespace SMBX64
             *out = false;
         else if(input == "#TRUE#")
             *out = true;
-        if(input == "false")
+        else if(input == "false")
             *out = false;
         else if(input == "true")
             *out = true;
@@ -181,7 +181,7 @@ namespace SMBX64
             *out = 0;
         else if(input == "#TRUE#")
             *out = 1;
-        if(input == "false")
+        else if(input == "false")
             *out = 0;
         else if(input == "true")
             *out = 1;
@@ -199,7 +199,7 @@ namespace SMBX64
             *out = 0;
         else if(input == "#TRUE#")
             *out = 1;
-        if(input == "false")
+        else if(input == "false")
             *out = 0;
         else if(input == "true")
             *out = 1;


### PR DESCRIPTION
Was found to be causing failures at opening .lvl files in a recent build.
