### PR TITLE
Support for 3DS (lacks working directory)

### DIFF
--- a/pge_file_lib_globs.cpp
+++ b/pge_file_lib_globs.cpp
@@ -1340,23 +1340,24 @@ void FileInfo::rebuildData()
     m_baseName.clear();
 
     //Take full path
+
 #ifdef PGE_FILES_QT
     m_filePath = QFileInfo(m_filePath).absoluteFilePath();
-#else
-#   ifndef _WIN32
+#elif defined(__3DS__)
+    // all paths are absolute on 3DS
+#elif !defined(_WIN32)
     char *rez = NULL;
     char buf[PATH_MAXLEN + 1];
     rez = realpath(m_filePath.c_str(), buf);
     if(rez)
         m_filePath = buf;
-#   else
+#else
     wchar_t bufW[MAX_PATH + 1];
     DWORD ret = 0;
     ret = GetFullPathNameW(Str2WStr(m_filePath).c_str(), MAX_PATH, bufW, nullptr);
     if(ret != 0)
         m_filePath = WStr2Str(bufW);
     std::replace(m_filePath.begin(), m_filePath.end(), '\\', '/');
-#   endif
 #endif
 
     //Read directory path


### PR DESCRIPTION
Tiny modification to allow compilation targeting 3DS (would also be relevant for other embedded platforms without working directories). These platforms do not implement the standard library function `realpath` because it is not useful on them.
Although this modification is very minor, it allows compilation of TheXTech and other PGE projects for these platforms. Thank you for your consideration!