### PR TITLE
Add support for PS Vita SDK either by passing -DVita=1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,25 @@
 cmake_minimum_required (VERSION 2.8.12)
+
+if(Vita OR VITA)
+
+message("VITASDK Defined!")
+message("VITA BUILD!")
+#set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
+set(CMAKE_TOOLCHAIN_FILE "/usr/local/vitasdk/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
+
+#include("${VITASDK}/share/vita.cmake" REQUIRED)
+include ("/usr/local/vitasdk/share/vita.cmake" REQUIRED)
+
+set(VITA 1)
+# set(VITA_APP_NAME "TheXTech Vita Edition")
+# set(VITA_TITLEID  "THEXTECH00001")
+# set(VITA_VERSION  "01.00")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcompare-debug-second -std=gnu11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcompare-debug-second -std=gnu++11 -fno-optimize-sibling-calls -Wno-class-conversion")
+set(PGEFL_QT_SUPPORT OFF)
+endif()
+
 project(PGEFileLibrary C CXX)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -26,7 +47,7 @@ endif()
 if(NOT PGEFL_QT_SUPPORT)
     option(PGEFL_QT_SUPPORT "Build also Qt variant" ${OPT_DEF_PGEFL_QT_SUPPORT})
 endif()
-if(PGEFL_QT_SUPPORT)
+if(PGEFL_QT_SUPPORT AND NOT VITA)
     message("== PGE-FL Qt Edition WILL be built!")
     if(POLICY CMP0071) # Automoc
         cmake_policy(SET CMP0071 NEW)

--- a/build_props.cmake
+++ b/build_props.cmake
@@ -108,7 +108,8 @@ if(MSVC)
 endif()
 
 # -fPIC thing
-if(LIBRARY_PROJECT AND NOT WIN32)
+if(LIBRARY_PROJECT AND NOT WIN32 AND NOT VITA)
+    message("-fPIC is on!")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()


### PR DESCRIPTION
 or by including this project in a project that is already building with the Vita SDK

Also fixes a bug where `-fPIC` was being passed for the PS Vita, when the PS Vita SDK doesn't work at all with the -fPIC flag. So we dont add the flag at all on PS Vita. 