### PR TITLE
[VITA, FIX] Follow 3DS code path for FileInfo::rebuildData 

### DIFF
--- a/pge_file_lib_globs.cpp
+++ b/pge_file_lib_globs.cpp
@@ -1343,7 +1343,7 @@ void FileInfo::rebuildData()
 
 #ifdef PGE_FILES_QT
     m_filePath = QFileInfo(m_filePath).absoluteFilePath();
-#elif defined(__3DS__)
+#elif defined(__3DS__) || defined(VITA)
     // all paths are absolute on 3DS
 #elif !defined(_WIN32)
     char *rez = NULL;


### PR DESCRIPTION
I had to make a small change here for the PS Vita, as `realpath` is not a supported function via the half implemented POSIX layer. Without making this change, the level metadata paths become corrupted and read data from other places on the SD/storage. 