### PR TITLE
[VITA] Removing unnecessary CMakeLists.txt Vita clause. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,9 @@ if(NOT CMAKE_DEBUG_POSTFIX)
     set(CMAKE_DEBUG_POSTFIX "d")
 endif()
 
-find_package(Qt5Core QUIET)
+if(NOT VITA)
+    find_package(Qt5Core QUIET)
+endif()
 
 if(VITA OR Qt5Core_FOUND)
     set(OPT_DEF_PGEFL_QT_SUPPORT OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,5 @@
 cmake_minimum_required (VERSION 2.8.12)
 
-if(Vita OR VITA)
-    message("VITASDK Defined!")
-    message("VITA BUILD!")
-    #set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
-    set(CMAKE_TOOLCHAIN_FILE "/usr/local/vitasdk/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
-
-    #include("${VITASDK}/share/vita.cmake" REQUIRED)
-    include("/usr/local/vitasdk/share/vita.cmake" REQUIRED)
-
-    set(VITA 1)
-    # set(VITA_APP_NAME "TheXTech Vita Edition")
-    # set(VITA_TITLEID  "THEXTECH00001")
-    # set(VITA_VERSION  "01.00")
-
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcompare-debug-second -std=gnu11")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcompare-debug-second -std=gnu++11 -fno-optimize-sibling-calls -Wno-class-conversion")
-    set(PGEFL_QT_SUPPORT OFF)
-endif()
-
 project(PGEFileLibrary C CXX)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -39,7 +20,7 @@ endif()
 
 find_package(Qt5Core QUIET)
 
-if(Qt5Core_FOUND)
+if(VITA OR Qt5Core_FOUND)
     set(OPT_DEF_PGEFL_QT_SUPPORT OFF)
 else()
     set(OPT_DEF_PGEFL_QT_SUPPORT ON)


### PR DESCRIPTION
Removing unnecessary CMakeLists.txt Vita clause. Ensure OPT_DEF_PGEFL_QT_SUPPORT is OFF for Vita

Following in the footsteps of TheXTech, if anyone wanted to build this library standalone for Vita they could run:
```sh
cmake -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake ../
```

By running the command like this, everything in the removed lines 3-21 are done. The only exception is `set(PGEFL_QT_SUPPORT OFF)` which doesn't do anything anyway.

At new line 23, I add the following:
```cmake
if(VITA OR Qt5Core_FOUND)
```
I add the VITA in there to ensure that PS Vita is not built with PGEFL_QT_SUPPORT. 
I thought it was a bit strange that the original statement was `if(Qt5Core_FOUND)` but I tagged in there and was successfully able to build for Vita without including/using Qt5 features. Please let me know if I should not have done that. 
